### PR TITLE
Trying to fix spec file for Fedora 34

### DIFF
--- a/olive-editor/olive-editor.spec
+++ b/olive-editor/olive-editor.spec
@@ -14,13 +14,14 @@ Summary:    Professional open-source NLE video editor
 License:    GPLv3
 URL:        https://www.olivevideoeditor.org
 Source0:    https://github.com/%{name}/%{shortname}/archive/%{version}.tar.gz
+Patch0:     olive.patch
 
 %{?rhel:BuildRequires:      qt5-qtbase-devel, qt5-qtmultimedia-devel, qt5-qtsvg-devel, qt5-linguist}
 %{?rhel:BuildRequires:      cmake3}
-%{?fedora:BuildRequires:    qt5-devel}
 %{?fedora:BuildRequires:    cmake}
-BuildRequires:              gcc, ffmpeg-devel, frei0r-devel
+BuildRequires:              g++, gcc, ffmpeg-devel, frei0r-devel
 BuildRequires:              desktop-file-utils, libappstream-glib
+BuildRequires:              mesa-libGL-devel,
 
 %{?rhel:Requires:    qt5-qtbase}
 %{?fedora:Requires:  qt5}
@@ -44,6 +45,7 @@ This package contains doxygen-generated html API documentation for %{name}.
 
 %prep
 %autosetup -n %{shortname}-%{version}
+
 
 %build
 %cmake -DBUILD_DOXYGEN=ON .

--- a/olive-editor/olive.patch
+++ b/olive-editor/olive.patch
@@ -1,0 +1,44 @@
+diff -ruN 0.1.2/olive-0.1.2/effects/internal/texteffect.cpp 0.1.2-new/olive-0.1.2/effects/internal/texteffect.cpp
+--- 0.1.2/olive-0.1.2/effects/internal/texteffect.cpp	2019-11-11 03:05:02.000000000 -0300
++++ 0.1.2-new/olive-0.1.2/effects/internal/texteffect.cpp	2021-06-30 08:32:06.850201000 -0300
+@@ -25,6 +25,7 @@
+ #include <QOpenGLTexture>
+ #include <QTextEdit>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPushButton>
+ #include <QColorDialog>
+ #include <QFontDatabase>
+diff -ruN 0.1.2/olive-0.1.2/effects/internal/timecodeeffect.cpp 0.1.2-new/olive-0.1.2/effects/internal/timecodeeffect.cpp
+--- 0.1.2/olive-0.1.2/effects/internal/timecodeeffect.cpp	2019-11-11 03:05:02.000000000 -0300
++++ 0.1.2-new/olive-0.1.2/effects/internal/timecodeeffect.cpp	2021-06-30 08:30:51.852980000 -0300
+@@ -25,6 +25,7 @@
+ #include <QOpenGLTexture>
+ #include <QTextEdit>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPushButton>
+ #include <QColorDialog>
+ #include <QFontDatabase>
+diff -ruN 0.1.2/olive-0.1.2/ui/graphview.cpp 0.1.2-new/olive-0.1.2/ui/graphview.cpp
+--- 0.1.2/olive-0.1.2/ui/graphview.cpp	2019-11-11 03:05:02.000000000 -0300
++++ 0.1.2-new/olive-0.1.2/ui/graphview.cpp	2021-06-30 08:30:05.435847000 -0300
+@@ -21,6 +21,7 @@
+ #include "graphview.h"
+ 
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QMouseEvent>
+ #include <QtMath>
+ #include <cfloat>
+diff -ruN 0.1.2/olive-0.1.2/ui/timelineheader.cpp 0.1.2-new/olive-0.1.2/ui/timelineheader.cpp
+--- 0.1.2/olive-0.1.2/ui/timelineheader.cpp	2019-11-11 03:05:02.000000000 -0300
++++ 0.1.2-new/olive-0.1.2/ui/timelineheader.cpp	2021-06-30 08:29:39.035772000 -0300
+@@ -21,6 +21,7 @@
+ #include "timelineheader.h"
+ 
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QMouseEvent>
+ #include <QScrollBar>
+ #include <QtMath>


### PR DESCRIPTION
I compiled the source code with this changes and it worked. I had to apply a patch adding the line "#include <QPainterPath>" on some files to fix some errors when compiling. I've never packaged an RPM before, so maybe this changes wont work for creating the RPM but it works for compiling the software.

I saw that the meta package "qt5-devel" doesn't exist anymore since Fedora 33, and it has been split on several packages, but it is possible to compile the source code with the packages required on this spec file.

I hope I've been able to help.